### PR TITLE
3d color & lighting, more solids

### DIFF
--- a/src/Diagrams/Backend/POVRay.hs
+++ b/src/Diagrams/Backend/POVRay.hs
@@ -27,10 +27,9 @@ import Data.Maybe
 
 import Diagrams.Core.Transform
 
-import Diagrams.Prelude hiding (fromDirection, view)
-import Diagrams.ThreeD
+import Diagrams.Prelude.ThreeD as D
 
-import Diagrams.Backend.POVRay.Syntax
+import Diagrams.Backend.POVRay.Syntax as P
 
 import Data.Typeable
 
@@ -55,6 +54,14 @@ instance Backend POVRay R3 where
 instance Renderable Ellipsoid POVRay where
   render _ (Ellipsoid t) = Pov [SIObject . OFiniteSolid $ s]
     where s = Sphere zeroV 1 [povrayTransf t]
+
+instance Renderable D.Box POVRay where
+    render _ (D.Box t) = Pov [SIObject . OFiniteSolid $ box]
+      where box = P.Box zeroV (VecLit 1 1 1) [povrayTransf t]
+
+instance Renderable Frustum POVRay where
+    render _ (Frustum r0 r1 t) = Pov [SIObject . OFiniteSolid $ f]
+      where f = Cone zeroV r0 (VecLit 0 0 1) r1 False [povrayTransf t]
 
 -- For perspective projection, forLen tells POVRay the horizontal
 -- field of view, and CVRight specifies the aspect ratio of the view.

--- a/src/Diagrams/Backend/POVRay/Syntax.hs
+++ b/src/Diagrams/Backend/POVRay/Syntax.hs
@@ -180,10 +180,18 @@ instance SDL TFinish where
 ------------------------------------------------------------
 
 data FiniteSolid = Sphere Vector Double [ObjectModifier]
+                 | Box Vector Vector [ObjectModifier]
+                 | Cone Vector Double Vector Double Bool [ObjectModifier]
 
 instance SDL FiniteSolid where
   toSDL (Sphere c r mods) = block "sphere" (cr : map toSDL mods)
     where cr = toSDL c <> comma <+> toSDL r
+  toSDL (Box p1 p2 mods) = block "box" (corners : map toSDL mods)
+    where corners = toSDL p1 <> comma <+> toSDL p2
+  toSDL (Cone p1 r1 p2 r2 o mods) = block "cone" (geom : open : map toSDL mods) where
+    open = if o then text " open" else empty
+    geom = toSDL p1 <> comma <+> toSDL r1 <> comma <+>
+           toSDL p2 <> comma <+> toSDL r2
 
 ------------------------------------------------------------
 -- Light sources
@@ -206,9 +214,13 @@ makePrisms ''ObjectModifier
 
 getMods :: FiniteSolid -> [ObjectModifier]
 getMods (Sphere _ _ ms) = ms
+getMods (Box _ _ ms) = ms
+getMods (Cone _ _ _ _ _ ms) = ms
 
 setMods :: FiniteSolid -> [ObjectModifier] -> FiniteSolid
-setMods (Sphere v r _) new = Sphere v r new 
+setMods (Sphere v r _) new = Sphere v r new
+setMods (Box p1 p2 _) new = Box p1 p2 new
+setMods (Cone p1 r1 p2 r2 o _) new = Cone p1 r1 p2 r2 o new
 
 mods :: Lens' FiniteSolid [ObjectModifier]
 mods = lens getMods setMods


### PR DESCRIPTION
This branch accompanies the changes in https://github.com/diagrams/diagrams-lib/pull/166.  `diagrams-povray` can represent everything that I've added to `diagrams-lib`, though this is only a small fraction of the shapes and lighting parameters that POV-Ray understands.
