### PR TITLE
Bump lens upper version bounds

### DIFF
--- a/diagrams-povray.cabal
+++ b/diagrams-povray.cabal
@@ -30,6 +30,6 @@ Library
                      containers >= 0.3 && < 0.6,
                      pretty >= 1.0.1.2 && < 1.2,
                      colour >= 2.3 && < 2.4,
-                     lens >= 4.0 && < 4.5,
+                     lens >= 4.0 && < 4.6,
                      linear >= 1.10 && < 1.11
   Default-language:  Haskell2010


### PR DESCRIPTION
Allow `diagrams-povray` to use the latest version of `lens` (4.5).
